### PR TITLE
Fixed capitalization on type check for newTime when setting time on SimpleTimer

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -14,7 +14,7 @@ module.exports = function(options){
           interval = setInterval(
             function(){
               timer.emit('poll', timer.time());
-            }, 
+            },
             options.pollInterval
           );
         }
@@ -49,7 +49,7 @@ module.exports = function(options){
 
   timer.time = function(newTime){
 
-    if(typeof newTime === 'Number'){
+    if(typeof newTime === 'number'){
       cumulative = newTime;
     }
 


### PR DESCRIPTION
The newTime type check was looking for "Number" when the type returned by typeof is actually "number".